### PR TITLE
perf: Optimize PDF map request parameters

### DIFF
--- a/application/frontend/src/app/core/services/pdf-download.service.ts
+++ b/application/frontend/src/app/core/services/pdf-download.service.ts
@@ -205,29 +205,29 @@ export class PdfDownloadService {
     );
   }
 
-  private visitToDeliveries(visits: VisitRequest[], icon: string): string {
+  private visitToDeliveries(visits: VisitRequest[], icon: string, precision = 6): string {
     return (
       `icon:${icon}|anchor:center|` +
       visits
         .map(
           (visit) =>
-            visit.arrivalWaypoint?.location?.latLng?.latitude +
+            visit.arrivalWaypoint?.location?.latLng?.latitude.toFixed(precision) +
             ',' +
-            visit.arrivalWaypoint?.location?.latLng?.longitude
+            visit.arrivalWaypoint?.location?.latLng?.longitude.toFixed(precision)
         )
         .join('|')
     );
   }
 
-  private visitsToPickups(visits: VisitRequest[], icon: string): string {
+  private visitsToPickups(visits: VisitRequest[], icon: string, precision = 6): string {
     return (
       `icon:${icon}|anchor:center|` +
       visits
         .map(
           (visit) =>
-            visit.arrivalWaypoint?.location?.latLng?.latitude +
+            visit.arrivalWaypoint?.location?.latLng?.latitude.toFixed(precision) +
             ',' +
-            visit.arrivalWaypoint?.location?.latLng?.longitude
+            visit.arrivalWaypoint?.location?.latLng?.longitude.toFixed(precision)
         )
         .join('|')
     );

--- a/application/frontend/src/app/util/linear-referencing.ts
+++ b/application/frontend/src/app/util/linear-referencing.ts
@@ -30,7 +30,7 @@ import {
 } from 'src/app/util/geo-translation';
 import buffer from '@turf/buffer';
 
-const SIMPLIFY_ROUTE_TOLERANCE = 0.0001;
+const SIMPLIFY_ROUTE_TOLERANCE = 0.0002;
 const RULER = cheapRuler(0, 'meters');
 
 export const getPointAlongPathByDistance = (


### PR DESCRIPTION
Closes #152 

This PR reduces the precision of marker lat/lngs and increases the level of simplification for route paths when generating maps for PDF export. These two changes reduce the length of the request parameters, allowing for previously failing PDF requests to now succeed.

As this is just a request length optimization, it is still possible that large requests will fail, and we may want to consider an alternative method for generating the PDF maps long term.