### PR TITLE
feat: Page dependent post-solve map selections

### DIFF
--- a/application/frontend/src/app/core/reducers/routes-chart.reducer.spec.ts
+++ b/application/frontend/src/app/core/reducers/routes-chart.reducer.spec.ts
@@ -86,7 +86,7 @@ describe('RoutesChart Reducer', () => {
     const newState = reducer(selectedState, RoutesChartActions.deselectRoute({ routeId: 111 }));
     expect(newState.selectedRoutes).not.toEqual(selectedState.selectedRoutes);
     expect(newState.selectedRoutes.length).toBe(0);
-    expect(newState.selectedRoutesColors[0]).not.toEqual(selectedState.selectedRoutesColors[0]);
+    expect(newState.selectedRoutesColors[0]).toEqual(selectedState.selectedRoutesColors[0]);
   });
 
   it('on deselectRoutes', () => {
@@ -99,7 +99,7 @@ describe('RoutesChart Reducer', () => {
     const newState = reducer(selectedState, RoutesChartActions.deselectRoutes({ routeIds: [111] }));
     expect(newState.selectedRoutes).not.toEqual(initialState.selectedRoutes);
     expect(newState.selectedRoutes.length).toBe(1);
-    expect(newState.selectedRoutesColors).not.toEqual(initialState.selectedRoutesColors);
+    expect(newState.selectedRoutesColors).toEqual(initialState.selectedRoutesColors);
   });
 
   it('on updateRoutesSelection', () => {

--- a/application/frontend/src/app/core/reducers/routes-chart.reducer.ts
+++ b/application/frontend/src/app/core/reducers/routes-chart.reducer.ts
@@ -65,10 +65,6 @@ export const reducer = createReducer(
     return {
       ...state,
       selectedRoutes,
-      selectedRoutesColors: fromMapTheme.getSelectedColors(
-        selectedRoutes,
-        state.selectedRoutesColors
-      ),
     };
   }),
   on(RoutesChartActions.selectRoutes, (state, { routeIds }) => {
@@ -77,10 +73,6 @@ export const reducer = createReducer(
     return {
       ...state,
       selectedRoutes,
-      selectedRoutesColors: fromMapTheme.getSelectedColors(
-        selectedRoutes,
-        state.selectedRoutesColors
-      ),
     };
   }),
   on(RoutesChartActions.deselectRoute, (state, { routeId }) => {
@@ -88,10 +80,6 @@ export const reducer = createReducer(
     return {
       ...state,
       selectedRoutes,
-      selectedRoutesColors: fromMapTheme.getSelectedColors(
-        selectedRoutes,
-        state.selectedRoutesColors
-      ),
     };
   }),
   on(RoutesChartActions.deselectRoutes, (state, { routeIds }) => {
@@ -99,10 +87,6 @@ export const reducer = createReducer(
     return {
       ...state,
       selectedRoutes,
-      selectedRoutesColors: fromMapTheme.getSelectedColors(
-        selectedRoutes,
-        state.selectedRoutesColors
-      ),
     };
   }),
   on(RoutesChartActions.updateRoutesSelection, (state, { addedRouteIds, removedRouteIds }) => {
@@ -110,14 +94,7 @@ export const reducer = createReducer(
     const retainedRoutes = state.selectedRoutes.filter((id) => !removedRouteIds.includes(id));
     const selectedRoutes = retainedRoutes.concat(addedRoutes);
 
-    const selectedRoutesColorMap = new Map(state.selectedRoutesColors);
-    removedRouteIds.forEach((key) => selectedRoutesColorMap.delete(key));
-    const selectedRoutesColors = fromMapTheme.getSelectedColors(
-      selectedRoutes,
-      Array.from(selectedRoutesColorMap.entries())
-    );
-
-    return { ...state, selectedRoutes, selectedRoutesColors };
+    return { ...state, selectedRoutes };
   }),
   on(RoutesChartActions.addFilter, (state, { filter }) => ({
     ...state,
@@ -151,8 +128,16 @@ export const reducer = createReducer(
   on(MainNavActions.solve, ValidationResultActions.solve, (state) => ({
     ...state,
     selectedRoutes: initialState.selectedRoutes,
-    selectedRoutesColors: initialState.selectedRoutesColors,
-  }))
+  })),
+  on(DispatcherActions.loadSolution, (state, solution) => {
+    return {
+      ...state,
+      selectedRoutesColors: fromMapTheme.getSelectedColors(
+        solution.shipmentRoutes.map((route) => route.id),
+        []
+      ),
+    };
+  })
 );
 
 export const selectSelectedRoutes = (state: State): number[] => state.selectedRoutes;

--- a/application/frontend/src/app/core/selectors/post-solve-vehicle-layer.selectors.ts
+++ b/application/frontend/src/app/core/selectors/post-solve-vehicle-layer.selectors.ts
@@ -24,20 +24,34 @@ import { vehicleToDeckGL } from './pre-solve-vehicle-layer.selectors';
 import RoutesChartSelectors from './routes-chart.selectors';
 import * as fromVehicle from './vehicle.selectors';
 import { MapLayerId } from '../models/map';
-import { TravelMode } from '../models';
+import { Page, TravelMode } from '../models';
+import RoutesMetadataSelectors from './routes-metadata.selectors';
+import * as fromUi from './ui.selectors';
 
 export const selectFilteredVehicles = createSelector(
   fromVehicle.selectEntities,
   selectVehicleStartLocationsOnRoute,
   selectVehicleHeadings,
+  fromUi.selectPage,
   RoutesChartSelectors.selectFilteredRoutesWithTransitionsLookup,
+  RoutesMetadataSelectors.selectFilteredRouteLookup,
   selectPostSolveMapLayers,
-  (vehicles, startLocations, headings, filteredRoutesLookup, mapLayers) => {
+  (
+    vehicles,
+    startLocations,
+    headings,
+    currentPage,
+    chartFilteredRoutesLookup,
+    metadataSelectedRoutesLookup,
+    mapLayers
+  ) => {
     const vehiclesArray = Object.values(vehicles);
-    const filteredVehicles = filteredRoutesLookup.size
+    const lookup =
+      currentPage === Page.RoutesChart ? chartFilteredRoutesLookup : metadataSelectedRoutesLookup;
+    const filteredVehicles = lookup.size
       ? vehiclesArray.filter(
           (v) =>
-            filteredRoutesLookup.has(v.id) &&
+            lookup.has(v.id) &&
             ((v.travelMode ?? TravelMode.DRIVING) === TravelMode.DRIVING
               ? mapLayers[MapLayerId.PostSolveFourWheel].visible
               : mapLayers[MapLayerId.PostSolveWalking].visible)
@@ -53,13 +67,26 @@ export const selectFilteredVehiclesSelected = createSelector(
   fromVehicle.selectEntities,
   selectVehicleStartLocationsOnRoute,
   selectVehicleHeadings,
+  fromUi.selectPage,
   RoutesChartSelectors.selectFilteredRoutesSelectedWithTransitionsLookup,
+  RoutesMetadataSelectors.selectFilteredRoutesSelectedLookup,
   RoutesChartSelectors.selectSelectedRoutesColors,
   selectPostSolveMapLayers,
-  (vehicles, startLocations, headings, selectedRoutesLookup, colors, mapLayers) => {
+  (
+    vehicles,
+    startLocations,
+    headings,
+    currentPage,
+    chartSelectedRoutesLookup,
+    metadataSelectedRoutesLookup,
+    colors,
+    mapLayers
+  ) => {
+    const metadataSet = new Set(Object.keys(metadataSelectedRoutesLookup).map(Number));
+    const lookup = currentPage === Page.RoutesChart ? chartSelectedRoutesLookup : metadataSet;
     const selectedVehicles = Object.values(vehicles).filter(
       (v) =>
-        selectedRoutesLookup.has(v.id) &&
+        lookup.has(v.id) &&
         ((v.travelMode ?? TravelMode.DRIVING) === TravelMode.DRIVING
           ? mapLayers[MapLayerId.PostSolveFourWheel].visible
           : mapLayers[MapLayerId.PostSolveWalking].visible)

--- a/application/frontend/src/app/core/selectors/route-layer.selectors.ts
+++ b/application/frontend/src/app/core/selectors/route-layer.selectors.ts
@@ -47,9 +47,14 @@ export const selectRoutes = createSelector(
 export const selectFilteredRoutes = createSelector(
   selectRoutes,
   RoutesChartSelectors.selectFilteredRouteIds,
+  RoutesMetadataSelectors.selectFilteredRouteIds,
+  fromUi.selectPage,
   fromVehicle.selectAll,
   selectPostSolveMapLayers,
-  (paths, filteredRouteIds, vehicles, mapLayers) => {
+  (paths, chartFilteredRouteIds, tableFilteredRouteIds, page, vehicles, mapLayers) => {
+    const filteredRouteIds = new Set(
+      page === Page.RoutesChart ? chartFilteredRouteIds : tableFilteredRouteIds
+    );
     return (filteredRouteIds ? paths.filter((p) => filteredRouteIds.has(p.id)) : paths).filter(
       (route) => {
         return (vehicles[route.vehicleIndex]?.travelMode ?? TravelMode.DRIVING) ===

--- a/application/frontend/src/app/core/selectors/route-layer.selectors.ts
+++ b/application/frontend/src/app/core/selectors/route-layer.selectors.ts
@@ -52,9 +52,8 @@ export const selectFilteredRoutes = createSelector(
   fromVehicle.selectAll,
   selectPostSolveMapLayers,
   (paths, chartFilteredRouteIds, tableFilteredRouteIds, page, vehicles, mapLayers) => {
-    const filteredRouteIds = new Set(
-      page === Page.RoutesChart ? chartFilteredRouteIds : tableFilteredRouteIds
-    );
+    const filteredRouteIds =
+      page === Page.RoutesChart ? chartFilteredRouteIds : new Set(tableFilteredRouteIds);
     return (filteredRouteIds ? paths.filter((p) => filteredRouteIds.has(p.id)) : paths).filter(
       (route) => {
         return (vehicles[route.vehicleIndex]?.travelMode ?? TravelMode.DRIVING) ===

--- a/application/frontend/src/app/core/selectors/routes-chart.selectors.ts
+++ b/application/frontend/src/app/core/selectors/routes-chart.selectors.ts
@@ -185,6 +185,15 @@ const selectFilteredRoutesSelected = createSelector(
   (routes, selected) => routes.filter((route) => selected[route.id])
 );
 
+const selectFilteredRoutesSelectedLookup = createSelector(
+  selectFilteredRoutesSelected,
+  (selected) => {
+    const filteredSelected = {} as { [id: number]: boolean };
+    selected.forEach((route) => (filteredSelected[route.id] = true));
+    return filteredSelected;
+  }
+);
+
 const selectTotalFilteredRoutes = createSelector(selectFilteredRoutes, (routes) => routes.length);
 
 const selectTotalFilteredRoutesSelected = createSelector(
@@ -353,6 +362,7 @@ export const RoutesChartSelectors = {
   selectFilteredRoutesVisitRequestIds,
   selectPagedRoutes,
   selectFilteredRoutesSelected,
+  selectFilteredRoutesSelectedLookup,
   selectTotalFilteredRoutes,
   selectTotalFilteredRoutesSelected,
   selectRanges,

--- a/application/frontend/src/app/core/selectors/routes-metadata.selectors.ts
+++ b/application/frontend/src/app/core/selectors/routes-metadata.selectors.ts
@@ -66,6 +66,10 @@ const selectSelectedRoutes = createSelector(
   (routes, selected) => routes.filter((route) => selected[route.id])
 );
 
+const selectedSelectedRoutesIds = createSelector(selectSelectedRoutes, (routes) =>
+  routes.map((route) => route.id)
+);
+
 const selectColumns = createSelector(selectRoutesMetadataState, (_state) => routeMetadataColumns);
 
 const selectActiveSortColumn = createSelector(selectSort, selectColumns, (sort, columns) =>
@@ -358,6 +362,7 @@ export const RoutesMetadataSelectors = {
   selectActiveSortColumn,
   selectColumns,
   selectSelectedRoutes,
+  selectedSelectedRoutesIds,
   selectSelectedLookup,
   selectSelected,
   selectSort,


### PR DESCRIPTION
Updates the post-solve map to use the selections and filters of the current view (Timeline or Table) independent of one another.