### PR TITLE
fix: CSV upload parsing and validation

### DIFF
--- a/application/frontend/src/app/core/containers/csv-upload-dialog/csv-upload-dialog.component.ts
+++ b/application/frontend/src/app/core/containers/csv-upload-dialog/csv-upload-dialog.component.ts
@@ -1240,7 +1240,24 @@ export class CsvUploadDialogComponent implements OnDestroy, OnInit {
             shipments = shipmentsResults.map((result) => result.shipment);
           }
           if (this.vehicleFile) {
-            vehicles = this.service.csvToVehicles(res[1].data, this.mappingFormVehicles.value);
+            const vehiclesResults = this.service.csvToVehicles(
+              res[1].data,
+              this.mappingFormVehicles.value
+            );
+
+            if (vehiclesResults.some((result) => result.errors.length)) {
+              vehiclesResults.forEach((result, index) => {
+                this.validationErrors.push(
+                  ...result.errors.map(
+                    (error) =>
+                      `Vehicle ${result.vehicle.label || ''} at index ${index}: ${error.message}`
+                  )
+                );
+              });
+              throw Error('Vehicle validation error');
+            }
+
+            vehicles = vehiclesResults.map((result) => result.vehicle);
           }
 
           // geocode all shipments, then all vehicles

--- a/application/frontend/src/app/core/services/csv.service.spec.ts
+++ b/application/frontend/src/app/core/services/csv.service.spec.ts
@@ -103,6 +103,53 @@ describe('CsvService', () => {
     });
   });
 
+  describe('Validate shipments', () => {
+    it('should not throw error on a valid shipment', () => {
+      const shipments = [{ label: 'test shipment' }];
+      const testMapping = { Label: 'label' };
+      const result = service.csvToShipments(shipments, testMapping);
+      expect(result.length).toBe(1);
+      expect(result[0].errors.length).toBe(0);
+    });
+
+    it('should not throw error on shipment with a valid load demand', () => {
+      const shipments = [
+        {
+          LoadDemand1Type: 'weight',
+          LoadDemand1Value: 10,
+        },
+      ];
+      const testMapping = {
+        LoadDemand1Type: 'LoadDemand1Type',
+        LoadDemand1Value: 'LoadDemand1Value',
+      };
+      const result = service.csvToShipments(shipments, testMapping);
+      expect(result.length).toBe(1);
+      expect(result[0].errors.length).toBe(0);
+    });
+
+    it('should throw an error on shipment with an invalid load demand', () => {
+      const shipments = [
+        {
+          LoadDemand1Type: 'weight',
+          LoadDemand1Value: 'invalid',
+        },
+        {
+          LoadDemand1Type: 'weight',
+          LoadDemand1Value: 10.5,
+        },
+      ];
+      const testMapping = {
+        LoadDemand1Type: 'LoadDemand1Type',
+        LoadDemand1Value: 'LoadDemand1Value',
+      };
+      const result = service.csvToShipments(shipments, testMapping);
+      expect(result.length).toBe(2);
+      expect(result[0].errors.length).toBe(1);
+      expect(result[1].errors.length).toBe(1);
+    });
+  });
+
   describe('Validate vehicles', () => {
     it('should throw no errors on a valid vehicle', () => {
       const vehicles = [{ label: 'test vehicle' }];

--- a/application/frontend/src/app/core/services/csv.service.spec.ts
+++ b/application/frontend/src/app/core/services/csv.service.spec.ts
@@ -104,7 +104,7 @@ describe('CsvService', () => {
   });
 
   describe('Validate vehicles', () => {
-    it('should throw no errors on a valid vehicle', async () => {
+    it('should throw no errors on a valid vehicle', () => {
       const vehicles = [{ label: 'test vehicle' }];
       const testVehicleMapping = { Label: 'label' };
       const result = service.csvToVehicles(vehicles, testVehicleMapping);
@@ -112,7 +112,7 @@ describe('CsvService', () => {
       expect(result[0].errors.length).toBe(0);
     });
 
-    it('should throw no errors on a vehicle with a valid load limit', async () => {
+    it('should throw no errors on a vehicle with a valid load limit', () => {
       const vehicles = [
         {
           label: 'test vehicle',
@@ -130,7 +130,7 @@ describe('CsvService', () => {
       expect(result[0].errors.length).toBe(0);
     });
 
-    it('should throw an error on a vehicle with a negative load limit', async () => {
+    it('should throw an error on a vehicle with a negative load limit', () => {
       const vehicles = [
         {
           label: 'test vehicle',
@@ -148,7 +148,7 @@ describe('CsvService', () => {
       expect(result[0].errors.length).toBe(1);
     });
 
-    it('should throw an error on a vehicle with a zero load limit', async () => {
+    it('should throw an error on a vehicle with a zero load limit', () => {
       const vehicles = [
         {
           label: 'test vehicle',
@@ -166,7 +166,7 @@ describe('CsvService', () => {
       expect(result[0].errors.length).toBe(1);
     });
 
-    it('should throw no errors on a vehicle with a valid travel mode', async () => {
+    it('should throw no errors on a vehicle with a valid travel mode', () => {
       const vehicles = [
         {
           label: 'test vehicle',
@@ -187,7 +187,7 @@ describe('CsvService', () => {
       expect(result[1].errors.length).toBe(0);
     });
 
-    it('should throw an error on vehicles with an invalid travel mode', async () => {
+    it('should throw an error on vehicles with an invalid travel mode', () => {
       const vehicles = [
         {
           label: 'test vehicle',

--- a/application/frontend/src/app/core/services/csv.service.spec.ts
+++ b/application/frontend/src/app/core/services/csv.service.spec.ts
@@ -102,4 +102,110 @@ describe('CsvService', () => {
       expect(parsedCsv).not.toContain(key);
     });
   });
+
+  describe('Validate vehicles', () => {
+    it('should throw no errors on a valid vehicle', async () => {
+      const vehicles = [{ label: 'test vehicle' }];
+      const testVehicleMapping = { Label: 'label' };
+      const result = service.csvToVehicles(vehicles, testVehicleMapping);
+      expect(result.length).toBe(1);
+      expect(result[0].errors.length).toBe(0);
+    });
+
+    it('should throw no errors on a vehicle with a valid load limit', async () => {
+      const vehicles = [
+        {
+          label: 'test vehicle',
+          LoadLimit1Type: 'weight',
+          LoadLimit1Value: 10,
+        },
+      ];
+      const testVehicleMapping = {
+        Label: 'label',
+        LoadLimit1Type: 'LoadLimit1Type',
+        LoadLimit1Value: 'LoadLimit1Value',
+      };
+      const result = service.csvToVehicles(vehicles, testVehicleMapping);
+      expect(result.length).toBe(1);
+      expect(result[0].errors.length).toBe(0);
+    });
+
+    it('should throw an error on a vehicle with a negative load limit', async () => {
+      const vehicles = [
+        {
+          label: 'test vehicle',
+          LoadLimit1Type: 'weight',
+          LoadLimit1Value: -10,
+        },
+      ];
+      const testVehicleMapping = {
+        Label: 'label',
+        LoadLimit1Type: 'LoadLimit1Type',
+        LoadLimit1Value: 'LoadLimit1Value',
+      };
+      const result = service.csvToVehicles(vehicles, testVehicleMapping);
+      expect(result.length).toBe(1);
+      expect(result[0].errors.length).toBe(1);
+    });
+
+    it('should throw an error on a vehicle with a zero load limit', async () => {
+      const vehicles = [
+        {
+          label: 'test vehicle',
+          LoadLimit1Type: 'weight',
+          LoadLimit1Value: 0,
+        },
+      ];
+      const testVehicleMapping = {
+        Label: 'label',
+        LoadLimit1Type: 'LoadLimit1Type',
+        LoadLimit1Value: 'LoadLimit1Value',
+      };
+      const result = service.csvToVehicles(vehicles, testVehicleMapping);
+      expect(result.length).toBe(1);
+      expect(result[0].errors.length).toBe(1);
+    });
+
+    it('should throw no errors on a vehicle with a valid travel mode', async () => {
+      const vehicles = [
+        {
+          label: 'test vehicle',
+          TravelMode: 'DRIVING',
+        },
+        {
+          label: 'test vehicle',
+          TravelMode: 'walking',
+        },
+      ];
+      const testVehicleMapping = {
+        Label: 'label',
+        TravelMode: 'TravelMode',
+      };
+      const result = service.csvToVehicles(vehicles, testVehicleMapping);
+      expect(result.length).toBe(2);
+      expect(result[0].errors.length).toBe(0);
+      expect(result[1].errors.length).toBe(0);
+    });
+
+    it('should throw an error on vehicles with an invalid travel mode', async () => {
+      const vehicles = [
+        {
+          label: 'test vehicle',
+          TravelMode: 'DRIVING',
+        },
+        {
+          label: 'test vehicle',
+          TravelMode: 'invalid',
+        },
+      ];
+      const testVehicleMapping = {
+        Label: 'label',
+        TravelMode: 'TravelMode',
+      };
+      const result = service.csvToVehicles(vehicles, testVehicleMapping);
+      expect(result.length).toBe(2);
+      expect(result[0].errors.length).toBe(0);
+      expect(result[1].errors.length).toBe(1);
+    });
+  });
 });

--- a/application/frontend/src/app/core/services/csv.service.ts
+++ b/application/frontend/src/app/core/services/csv.service.ts
@@ -27,6 +27,7 @@ import {
   ILatLng,
   IShipment,
   IVehicle,
+  TravelMode,
   ValidationErrorResponse,
 } from '../models';
 import { FileService } from './file.service';
@@ -261,7 +262,13 @@ export class CsvService {
       // Conditionally add each field to the vehicle object, converting from csv strings as needed
       const parsedVehicle = {
         ...this.mapKeyToModelValue('label', 'Label', vehicle, mapping),
-        ...this.mapKeyToModelValue('travelMode', 'TravelMode', vehicle, mapping),
+        ...this.mapKeyToModelValue(
+          'travelMode',
+          'TravelMode',
+          vehicle,
+          mapping,
+          this.parseTravelMode
+        ),
         ...this.mapKeyToModelValue('unloadingPolicy', 'UnloadingPolicy', vehicle, mapping),
         ...this.mapKeyToModelValue('startWaypoint', 'StartWaypoint', vehicle, mapping),
         ...this.mapKeyToModelValue('endWaypoint', 'EndWaypoint', vehicle, mapping),
@@ -534,6 +541,10 @@ export class CsvService {
     } catch {
       return null;
     }
+  }
+
+  private parseTravelMode(value: string): number {
+    return TravelMode[value];
   }
 
   // Check map has the provided mapKey and if the model object has a value for the converted key

--- a/application/frontend/src/app/core/services/csv.service.ts
+++ b/application/frontend/src/app/core/services/csv.service.ts
@@ -318,6 +318,28 @@ export class CsvService {
   private validateVehicle(vehicle: IVehicle): ValidationErrorResponse[] {
     const errors = [];
 
+    const loadLimitsError = Object.keys(vehicle.loadLimits).some((limitKey) => {
+      const limit = vehicle.loadLimits[limitKey];
+      const value = Number.parseFloat(limit.maxLoad as string)
+      return !Number.isInteger(value) || value < 1;
+    })
+
+    if (loadLimitsError) {
+      errors.push({
+        error: true,
+        message: 'Vehicle contains invalid load limits',
+        vehicle
+      });
+    }
+
+    if (!vehicle.travelMode) {
+      errors.push({
+        error: true,
+        message: 'Vehicle has an invalid travel mode',
+        vehicle
+      });
+    }
+
     return errors;
   }
 

--- a/application/frontend/src/app/core/services/csv.service.ts
+++ b/application/frontend/src/app/core/services/csv.service.ts
@@ -257,7 +257,10 @@ export class CsvService {
     return errors;
   }
 
-  csvToVehicles(csvVehicles: any[], mapping: { [key: string]: string }): IVehicle[] {
+  csvToVehicles(
+    csvVehicles: any[],
+    mapping: { [key: string]: string }
+  ): { vehicle: IVehicle; errors: ValidationErrorResponse[] }[] {
     return csvVehicles.map((vehicle) => {
       // Conditionally add each field to the vehicle object, converting from csv strings as needed
       const parsedVehicle = {
@@ -305,8 +308,17 @@ export class CsvService {
         ...this.mapToLoadLimits(vehicle, mapping),
         ...this.mapToVehicleTimeWindows(vehicle, mapping),
       };
-      return parsedVehicle;
+      return {
+        vehicle: parsedVehicle,
+        errors: this.validateVehicle(parsedVehicle),
+      };
     });
+  }
+
+  private validateVehicle(vehicle: IVehicle): ValidationErrorResponse[] {
+    const errors = [];
+
+    return errors;
   }
 
   private mapToPickup(shipment: any, mapping: { [key: string]: string }, timeWindow: any): any {

--- a/application/frontend/src/app/core/services/csv.service.ts
+++ b/application/frontend/src/app/core/services/csv.service.ts
@@ -578,7 +578,7 @@ export class CsvService {
   }
 
   private parseTravelMode(value: string): number {
-    return TravelMode[value];
+    return TravelMode[value.toUpperCase()];
   }
 
   // Check map has the provided mapKey and if the model object has a value for the converted key

--- a/application/frontend/src/app/core/services/csv.service.ts
+++ b/application/frontend/src/app/core/services/csv.service.ts
@@ -320,23 +320,23 @@ export class CsvService {
 
     const loadLimitsError = Object.keys(vehicle.loadLimits).some((limitKey) => {
       const limit = vehicle.loadLimits[limitKey];
-      const value = Number.parseFloat(limit.maxLoad as string)
+      const value = Number.parseFloat(limit.maxLoad as string);
       return !Number.isInteger(value) || value < 1;
-    })
+    });
 
     if (loadLimitsError) {
       errors.push({
         error: true,
         message: 'Vehicle contains invalid load limits',
-        vehicle
+        vehicle,
       });
     }
 
-    if (!vehicle.travelMode) {
+    if ('travelMode' in vehicle && !vehicle.travelMode) {
       errors.push({
         error: true,
         message: 'Vehicle has an invalid travel mode',
-        vehicle
+        vehicle,
       });
     }
 


### PR DESCRIPTION
Properly parse travel modes from CSVs so that valid enum values are stored internally. As an additional safety check, adds additional user-facing validation when parsing vehicles.

Fixes #177 
