### PR TITLE
fix: zip validation order

### DIFF
--- a/application/frontend/src/app/core/containers/upload-dialog/upload-dialog.component.ts
+++ b/application/frontend/src/app/core/containers/upload-dialog/upload-dialog.component.ts
@@ -331,11 +331,13 @@ export class UploadDialogComponent {
     let solution;
     files.forEach((file) => {
       if (!scenario || !Object.keys(scenario).length) {
-        scenario = this.validateScenario(file.content);
+        const res = this.validateScenario(file.content);
+        scenario = res.isValid ? res.scenario : null;
       }
 
       if (!solution || !Object.keys(solution).length) {
-        solution = this.validateSolution(file.content);
+        const res = this.validateSolution(file.content);
+        solution = res.isValid ? res.solution : null;
       }
     });
 
@@ -374,35 +376,32 @@ export class UploadDialogComponent {
    * Only validates the message/value structure
    */
   scenarioValidator(_: UntypedFormControl): ValidationErrors | null {
-    try {
-      const scenario = this.validateScenario(this.json);
-
-      if (this.scenario == null) {
-        this.scenario = scenario;
-      }
-    } catch (error) {
+    const res = this.validateScenario(this.json);
+    if (this.scenario == null && res.isValid) {
+      this.scenario = res.scenario;
+      return null;
+    } else {
       // eslint-disable-next-line no-console
-      console.log('Invalid request format:', error);
+      console.error(res.validationResult);
       return { requestFormat: true };
     }
-    return null;
   }
 
-  validateScenario(json: any): Scenario {
+  validateScenario(json: any): { scenario: Scenario; isValid: boolean; validationResult?: any } {
     const validationResult = this.uploadService.validateScenarioFormat(json);
     if (validationResult) {
-      throw validationResult;
+      return { scenario: null, isValid: false, validationResult };
     }
 
-    return this.dispatcherService.objectToScenario(json);
+    return { scenario: this.dispatcherService.objectToScenario(json), isValid: true };
   }
 
-  validateSolution(json: any): Solution {
+  validateSolution(json: any): { solution: Solution; isValid: boolean; validationResult?: any } {
     const validationResult = this.uploadService.validateSolutionFormat(json);
     if (validationResult) {
-      throw validationResult;
+      return { solution: null, isValid: false, validationResult };
     }
 
-    return this.dispatcherService.objectToSolution(json);
+    return { solution: this.dispatcherService.objectToSolution(json), isValid: true };
   }
 }

--- a/application/frontend/src/app/core/containers/upload-dialog/upload-dialog.component.ts
+++ b/application/frontend/src/app/core/containers/upload-dialog/upload-dialog.component.ts
@@ -337,13 +337,11 @@ export class UploadDialogComponent {
     let solution;
     files.forEach((file) => {
       if (!scenario || !Object.keys(scenario).length) {
-        const res = this.validateScenario(file.content);
-        scenario = res.isValid ? res.scenario : null;
+        scenario = this.validateScenario(file.content).scenario;
       }
 
       if (!solution || !Object.keys(solution).length) {
-        const res = this.validateSolution(file.content);
-        solution = res.isValid ? res.solution : null;
+        solution = this.validateSolution(file.content).solution;
       }
     });
 

--- a/application/frontend/src/app/core/containers/upload-dialog/upload-dialog.component.ts
+++ b/application/frontend/src/app/core/containers/upload-dialog/upload-dialog.component.ts
@@ -163,6 +163,12 @@ export class UploadDialogComponent {
       return;
     }
 
+    this.fileInvalid = false;
+    this.zipContentsInvalid = false;
+    this.zipContentCountInvalid = false;
+    this.zipMissingScenario = false;
+    this.zipMissingSolution = false;
+
     this.selectedFilename = file.name.replace(/\.[^/.]+$/, '');
 
     this.validatingUpload = true;


### PR DESCRIPTION
Removes thrown errors from upload validation and instead returns an object, allowing zip to be properly crawled while maintaining vaildation results.

Also fixes a validation bug where previous zip errors would take precedence over more recent file upload errors.

Closes #237 